### PR TITLE
Add a version to the executable

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -6,6 +6,7 @@ cd build
 cmake \
     -DCMAKE_INSTALL_PREFIX=${PREFIX} \
     -DCMAKE_INSTALL_LIBDIR=lib \
+    -DGIT_DESCRIBE=${GIT_DESCRIBE_HASH} \
     ..
 
 make -j"${CPU_COUNT}" install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   # Download the tar-ball and do `openssl sha256 file.tar.gz` to update
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
The initial executable doesn't have the embedded version number since there is no `.git` directory in the tarball. After reworking how the version number is set, it is now able to be passed in directly by external systems. Thats what I've done here.