### PR TITLE
Fix including the `rc` label in the `main` branch

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -7,7 +7,7 @@ cdt_name:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge rc
+- conda-forge main
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge rc
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -7,7 +7,7 @@ c_compiler_version:
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge rc
+- conda-forge main
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,7 +1,7 @@
 channel_sources:
 - conda-forge
 channel_targets:
-- conda-forge rc
+- conda-forge main
 openblas:
 - 0.3.*
 target_platform:

--- a/README.md
+++ b/README.md
@@ -78,14 +78,14 @@ Current release info
 Installing openfast
 ===================
 
-Installing `openfast` from the `conda-forge/label/rc` channel can be achieved by adding `conda-forge/label/rc` to your channels with:
+Installing `openfast` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
-conda config --add channels conda-forge/label/rc
+conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge/label/rc` channel has been enabled, `openfast` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `openfast` can be installed with `conda`:
 
 ```
 conda install openfast
@@ -100,26 +100,26 @@ mamba install openfast
 It is possible to list all of the versions of `openfast` available on your platform with `conda`:
 
 ```
-conda search openfast --channel conda-forge/label/rc
+conda search openfast --channel conda-forge
 ```
 
 or with `mamba`:
 
 ```
-mamba search openfast --channel conda-forge/label/rc
+mamba search openfast --channel conda-forge
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search openfast --channel conda-forge/label/rc
+mamba repoquery search openfast --channel conda-forge
 
 # List packages depending on `openfast`:
-mamba repoquery whoneeds openfast --channel conda-forge/label/rc
+mamba repoquery whoneeds openfast --channel conda-forge
 
 # List dependencies of `openfast`:
-mamba repoquery depends openfast --channel conda-forge/label/rc
+mamba repoquery depends openfast --channel conda-forge
 ```
 
 

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,0 @@
-channel_targets:
-  - conda-forge rc


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

PR #39 specified the channel target as `rc` even though the `main` branch should target the `main` label. This PR fixes this issue by removing `conda_build_config.yaml`.